### PR TITLE
bump automation extension version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,7 +39,7 @@ parts:
   gnome-sudoku:
 # ext:updatesnap
 #   version-format:
-#     lower-than: '44'
+#     lower-than: '46'
 #     no-9x-revisions: true
     source: https://gitlab.gnome.org/GNOME/gnome-sudoku.git
     source-type: git


### PR DESCRIPTION
bumping automation extension version to pull gnome 45 tags